### PR TITLE
Add the missing required subjects extra property field

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -86,6 +86,14 @@
                 }
             ]
         },
+        {
+            "category": "subjects",
+            "values": [
+                {
+                    "value": "1"
+                }
+            ]
+        },
 		{
 			"category": "contact",
 			"values": [


### PR DESCRIPTION
Extra properties were not all being tested on DATS.json and the following PR https://github.com/CONP-PCNO/conp-dataset/pull/498 revealed that the DATS.json file of bigbrain-datalad was missing the required extra property 'subjects'.

This PR should fix the issue.
