### PR TITLE
Add ARK identifier to DATS file

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -1,6 +1,10 @@
 {
     "title": "BigBrain dataset",
     "description": "The BigBrain dataset is a digitized reconstruction of high-resolution histological sections of the brain of a 65 years old man with no history of neurological or psychiatric diseases. This dataset is the result of a collaborative effort between the teams of Dr. Katrin Amunts and Dr. Karl Zilles (Forschungszentrum Jülich) and Dr. Alan Evans (Montreal Neurological Institute). For more information please visit the BigBrain Project website [https://bigbrainproject.org]. This dataset contains the 3D 40 microns blocks of the BigBrain as well as the 3D histological volumes at different isotropic resolutions (100 to 400 microns) in MNI space and histological space.",
+    "identifier": {
+        "identifier": "https://n2t.net/ark:/70798/d7k3xtt8440k06khv0",
+        "identifierSource": "CONP ARK ID"
+    },
     "licenses": [
 		{
             "@type": "License",


### PR DESCRIPTION
This adds the bigbrain dataset ARK identifier generated by the portal.